### PR TITLE
feat(metrics): add commits_count metric

### DIFF
--- a/pkg/client/client_repository.go
+++ b/pkg/client/client_repository.go
@@ -31,23 +31,34 @@ type repositoryInfoQuery struct {
 				}
 			}
 		} `graphql:"languages(first: 100)"`
+		DefaultBranchRef struct {
+			Name   string
+			Target struct {
+				Commit struct {
+					History struct {
+						TotalCount int
+					}
+				} `graphql:"... on Commit"`
+			}
+		}
 	} `graphql:"repository(owner: $owner, name: $name)"`
 }
 
 type RepositoryInfo struct {
 	// DiskUsage is returned in KBytes
-	DiskUsage  int
-	Forks      int
-	Stargazers int
-	Watchers   int
-	IsPrivate  bool
-	IsArchived bool
-	IsDisabled bool
-	IsFork     bool
-	IsLocked   bool
-	IsMirror   bool
-	IsTemplate bool
-	Languages  map[string]int
+	DiskUsage    int
+	Forks        int
+	Stargazers   int
+	Watchers     int
+	IsPrivate    bool
+	IsArchived   bool
+	IsDisabled   bool
+	IsFork       bool
+	IsLocked     bool
+	IsMirror     bool
+	IsTemplate   bool
+	Languages    map[string]int
+	CommitsCount int
 }
 
 func (c *Client) RepositoryInfo(owner string, name string) (*RepositoryInfo, error) {
@@ -72,18 +83,19 @@ func (c *Client) RepositoryInfo(owner string, name string) (*RepositoryInfo, err
 	}
 
 	info := &RepositoryInfo{
-		DiskUsage:  q.Repository.DiskUsage,
-		Forks:      q.Repository.ForkCount,
-		Stargazers: q.Repository.Stargazers.TotalCount,
-		Watchers:   q.Repository.Watchers.TotalCount,
-		IsPrivate:  q.Repository.IsPrivate,
-		IsArchived: q.Repository.IsArchived,
-		IsDisabled: q.Repository.IsDisabled,
-		IsFork:     q.Repository.IsFork,
-		IsLocked:   q.Repository.IsLocked,
-		IsMirror:   q.Repository.IsMirror,
-		IsTemplate: q.Repository.IsTemplate,
-		Languages:  map[string]int{},
+		DiskUsage:    q.Repository.DiskUsage,
+		Forks:        q.Repository.ForkCount,
+		Stargazers:   q.Repository.Stargazers.TotalCount,
+		Watchers:     q.Repository.Watchers.TotalCount,
+		IsPrivate:    q.Repository.IsPrivate,
+		IsArchived:   q.Repository.IsArchived,
+		IsDisabled:   q.Repository.IsDisabled,
+		IsFork:       q.Repository.IsFork,
+		IsLocked:     q.Repository.IsLocked,
+		IsMirror:     q.Repository.IsMirror,
+		IsTemplate:   q.Repository.IsTemplate,
+		Languages:    map[string]int{},
+		CommitsCount: q.Repository.DefaultBranchRef.Target.Commit.History.TotalCount,
 	}
 
 	for _, lang := range q.Repository.Languages.Edges {

--- a/pkg/fetcher/jobs.go
+++ b/pkg/fetcher/jobs.go
@@ -49,6 +49,7 @@ func (f *Fetcher) processUpdateRepoInfos(repo *github.Repository, log logrus.Fie
 			r.IsMirror = info.IsMirror
 			r.IsTemplate = info.IsTemplate
 			r.Languages = info.Languages
+			r.CommitsCount = info.CommitsCount
 
 			return nil
 		})

--- a/pkg/github/repository.go
+++ b/pkg/github/repository.go
@@ -28,6 +28,7 @@ type Repository struct {
 	IsMirror       bool
 	IsTemplate     bool
 	Languages      map[string]int
+	CommitsCount   int
 	FetchedAt      *time.Time
 
 	lock sync.RWMutex

--- a/pkg/metrics/collector.go
+++ b/pkg/metrics/collector.go
@@ -116,6 +116,7 @@ func (mc *Collector) collectRepoInfo(ch chan<- prometheus.Metric, repo *github.R
 	ch <- constMetric(repositoryLocked, prometheus.GaugeValue, boolVal(repo.IsLocked), repoName)
 	ch <- constMetric(repositoryMirror, prometheus.GaugeValue, boolVal(repo.IsMirror), repoName)
 	ch <- constMetric(repositoryTemplate, prometheus.GaugeValue, boolVal(repo.IsTemplate), repoName)
+	ch <- constMetric(repositoryCommitsCount, prometheus.GaugeValue, float64(repo.CommitsCount), repoName)
 
 	for language, size := range repo.Languages {
 		ch <- constMetric(repositoryLanguageSize, prometheus.GaugeValue, float64(size), repoName, language)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -94,6 +94,13 @@ var (
 		nil,
 	)
 
+	repositoryCommitsCount = prometheus.NewDesc(
+		"github_exporter_repo_commits_count",
+		"Number of commits in the default branch",
+		[]string{"repo"},
+		nil,
+	)
+
 	//////////////////////////////////////////////
 	// pull requests
 


### PR DESCRIPTION
This PR introduces a new metric, `github_exporter_repo_commits_count`.
It returns the total commits in the default branch (i.e usually main/master).

The goal is to provide more activity metrics on our GitHub dashboard.

![image](https://user-images.githubusercontent.com/52412651/193822904-1de8fd8a-de1a-4e4b-9d20-7dc024aab5c3.png)
